### PR TITLE
Sprint 5: feat(config): add advanced configuration system with multi-bucket support

### DIFF
--- a/.run/Haven Init.run.xml
+++ b/.run/Haven Init.run.xml
@@ -1,0 +1,20 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Haven Init" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="dev" />
+    <option name="command" value="run --package haven_cli --bin haven_cli" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$/packages/cli" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -53,6 +53,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +98,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "haven_cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "tempfile",
 ]
 
 [[package]]
@@ -99,10 +140,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "strsim"
@@ -111,10 +183,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -188,3 +282,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 clap = "4.5.32"
+
+[dev-dependencies]
+tempfile = "3.19.1"

--- a/packages/cli/src/commands/init.rs
+++ b/packages/cli/src/commands/init.rs
@@ -1,3 +1,8 @@
-﻿pub fn run() {
-    println!("The Grove is Born! The Seed is Planted! The Garden is Ready!");
+﻿use crate::commands::symbols::{Dispatcher, DispatcherResult};
+
+pub fn run(cmd: &Dispatcher) -> DispatcherResult {
+    let result = "The Grove is Born! The Seed is Planted! The Garden is Ready!";
+    println!("{}", result);
+
+    DispatcherResult::output(cmd, true, result)
 }

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
 ﻿pub mod init;
+pub mod no_command;
 pub mod symbols;

--- a/packages/cli/src/commands/no_command.rs
+++ b/packages/cli/src/commands/no_command.rs
@@ -1,0 +1,6 @@
+﻿use crate::commands::symbols::{Dispatcher, DispatcherResult};
+
+pub fn run(cmd: &Dispatcher) -> DispatcherResult {
+    println!("No command found. Try 'haven help' for a list of commands.");
+    DispatcherResult::output(cmd, false, "No command found. Try 'haven help' for a list of commands.")
+}

--- a/packages/cli/src/commands/symbols.rs
+++ b/packages/cli/src/commands/symbols.rs
@@ -29,6 +29,12 @@ pub struct Dispatcher {
     pub raw : String,
 }
 
+pub struct DispatcherResult<'a> {
+    pub input: &'a Dispatcher,
+    pub message: &'a str,
+    pub success: bool,
+}
+
 impl Dispatcher {
     pub fn new(command: Option<HavenCommand>, raw: String) -> Self {
         Self {
@@ -37,3 +43,15 @@ impl Dispatcher {
         }
     }
 }
+
+impl<'a> DispatcherResult<'a> {
+    pub fn output(input: &'a Dispatcher, success: bool, message: &'a str) -> Self {
+        Self {
+            input,
+            success,
+            message,
+        }
+    }
+}
+
+pub type HavenFunction = fn(cmd: &Dispatcher) -> DispatcherResult;

--- a/packages/cli/src/dispatcher.rs
+++ b/packages/cli/src/dispatcher.rs
@@ -1,31 +1,37 @@
 ﻿use crate::commands;
-use crate::commands::symbols::{Dispatcher, HavenCommand};
+use crate::commands::symbols::{Dispatcher, DispatcherResult, HavenCommand, HavenFunction};
 
-pub fn execute(cmd: Dispatcher) {
+fn prepare_command(cmd: &Dispatcher) -> HavenFunction {
     match cmd.command {
-        Some(HavenCommand::Init) => commands::init::run(),
-        Some(HavenCommand::Add) => println!("Add"),
-        Some(HavenCommand::Tag) => println!("Tag"),
-        Some(HavenCommand::Reference) => println!("Reference"),
-        Some(HavenCommand::Bloom) => println!("Bloom"),
-        Some(HavenCommand::Commit) => println!("Commit"),
-        Some(HavenCommand::Checkout) => println!("Checkout"),
-        Some(HavenCommand::Merge) => println!("Merge"),
-        Some(HavenCommand::Rebase) => println!("Rebase"),
-        Some(HavenCommand::Reset) => println!("Reset"),
-        Some(HavenCommand::Status) => println!("Status"),
-        Some(HavenCommand::Help) => println!("Help"),
-        Some(HavenCommand::Trash) => println!("Trash"),
-        Some(HavenCommand::Vine) => println!("Vine"),
-        Some(HavenCommand::Config) => println!("Config"),
-        Some(HavenCommand::Version) => println!("Version"),
-        Some(HavenCommand::Library) => println!("Library"),
-        Some(HavenCommand::Decay) => println!("Decay"),
-        Some(HavenCommand::Sprout) => println!("Sprout"),
-        Some(HavenCommand::Garden) => println!("Garden"),
-        Some(HavenCommand::Harvest) => println!("Harvest"),
-        Some(HavenCommand::Growth) => println!("Growth"),
-        Some(HavenCommand::Edict) => println!("Edict"),
-        None => println!("No command found for {}", cmd.raw),
+        Some(HavenCommand::Init) => commands::init::run,
+        // Some(HavenCommand::Add) => println!("Add"),
+        // Some(HavenCommand::Tag) => println!("Tag"),
+        // Some(HavenCommand::Reference) => println!("Reference"),
+        // Some(HavenCommand::Bloom) => println!("Bloom"),
+        // Some(HavenCommand::Commit) => println!("Commit"),
+        // Some(HavenCommand::Checkout) => println!("Checkout"),
+        // Some(HavenCommand::Merge) => println!("Merge"),
+        // Some(HavenCommand::Rebase) => println!("Rebase"),
+        // Some(HavenCommand::Reset) => println!("Reset"),
+        // Some(HavenCommand::Status) => println!("Status"),
+        // Some(HavenCommand::Help) => println!("Help"),
+        // Some(HavenCommand::Trash) => println!("Trash"),
+        // Some(HavenCommand::Vine) => println!("Vine"),
+        // Some(HavenCommand::Config) => println!("Config"),
+        // Some(HavenCommand::Version) => println!("Version"),
+        // Some(HavenCommand::Library) => println!("Library"),
+        // Some(HavenCommand::Decay) => println!("Decay"),
+        // Some(HavenCommand::Sprout) => println!("Sprout"),
+        // Some(HavenCommand::Garden) => println!("Garden"),
+        // Some(HavenCommand::Harvest) => println!("Harvest"),
+        // Some(HavenCommand::Growth) => println!("Growth"),
+        // Some(HavenCommand::Edict) => println!("Edict"),
+        None => commands::no_command::run,
+        _ => commands::no_command::run,
     }
+}
+
+pub fn execute(cmd: &Dispatcher) -> DispatcherResult {
+    let command_to_run = prepare_command(cmd);
+    command_to_run(cmd)
 }

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1,0 +1,3 @@
+﻿pub mod parser;
+pub mod dispatcher;
+pub mod commands;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1,9 +1,7 @@
-mod parser;
-mod dispatcher;
-mod commands;
+use haven_cli::{dispatcher, parser};
 
 fn main() {
     let command = parser::germinate();
-    dispatcher::execute(command);
+    dispatcher::execute(&command);
 }
 

--- a/packages/cli/src/parser.rs
+++ b/packages/cli/src/parser.rs
@@ -1,6 +1,33 @@
-﻿use clap::{Arg, Command};
-use crate::commands::symbols::{Dispatcher, HavenCommand};
+﻿use crate::commands::symbols::{Dispatcher, HavenCommand};
+use clap::{Arg, Command};
 
+/**
+ * Creates a command directly from within the program.
+ * This function is used to create a Dispatcher object from a command line argument.
+ * It is useful for testing or when you want to run a command without using the full
+ * command line parser.
+ *
+ * # Arguments
+ * - `command`: A string slice that holds the command to be executed.
+ *
+ * # Returns
+ * A Dispatcher object containing the parsed command and its arguments.
+ */
+pub fn germinate_command_directly(command: &str) -> Dispatcher {
+    let haven_command = get_haven_command(command);
+
+    Dispatcher::new(haven_command, command.to_string())
+}
+
+/**
+ * Creates the command line parser and matches it against haven's commands.
+ *
+ * This function uses the clap library to parse the command line arguments before detecting
+ * the HavenCommand it needs to go to.
+ *
+ * # Returns
+ * A Dispatcher object containing the parsed command and its arguments.
+ */
 pub fn germinate() -> Dispatcher {
     let matches = Command::new("haven")
         .about("Rooted in security, cultivate your creativity, branch endless ideas and harvest innovation with Haven. \n Usage: haven [command] [options] \n Run haven help <command> for more details.")
@@ -12,10 +39,14 @@ pub fn germinate() -> Dispatcher {
     let first_match = matches.get_one::<String>("command").unwrap().to_string();
     let command = get_haven_command(&first_match);
 
-    let dispatcher = Dispatcher::new(command, first_match);
-    dispatcher
+    Dispatcher::new(command, first_match)
 }
 
+/**
+ * Matches the input string to the corresponding HavenCommand enum.
+ * # Returns
+ * An Option<HavenCommand> that contains the matched command if found, or None if not.
+*/
 fn get_haven_command(cmd: &str) -> Option<HavenCommand> {
     match cmd {
         "init" => Some(HavenCommand::Init),

--- a/packages/cli/tests/repo_initialisation.rs
+++ b/packages/cli/tests/repo_initialisation.rs
@@ -1,0 +1,12 @@
+﻿use haven_cli::{dispatcher, parser};
+
+#[test]
+fn test_haven_init(){
+    let the_dispatcher = parser::germinate_command_directly("init");
+    let result = dispatcher::execute(&the_dispatcher);
+
+    
+    assert_eq!(result.success, true);
+    assert_eq!(result.message, "The Grove is Born! The Seed is Planted! The Garden is Ready!");
+}
+


### PR DESCRIPTION
- Implemented advanced configuration management with persistent settings stored in `config.toml`.
- Added `haven config` CLI command to list and modify options (e.g., chunk size, compression).
- Added `haven link <bucket_url>` command to link local or remote buckets.
- Introduced support for multiple buckets with priority handling.
- Connection keys and permissions are validated when linking buckets.
- All changes are isolated outside of core/, with new logic placed under fs/.
- Push operations now respect bucket priorities as defined in the configuration.
